### PR TITLE
Remove OpenMP parallelization

### DIFF
--- a/lib/hpx/_core.cpp
+++ b/lib/hpx/_core.cpp
@@ -139,7 +139,7 @@ static void LinearSphericalInterpolator_loop(char **args,
 {
     CGAL::Data_access<PointValueMap> values(
         *LinearSphericalInterpolator_current->point_value_map);
-    #pragma omp parallel for
+
     for (npy_intp i = 0; i < dimensions[0]; i++)
     {
         double xyz[3];

--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,6 @@ add_project_arguments(
 add_project_dependencies(
     dependency('numpy'),
     dependency('CGAL'),
-    dependency('openmp', required: false),
     language: 'cpp')
 
 py.install_sources('lib/hpx/__init__.py', subdir: 'hpx')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,28 +16,14 @@ requires = [
 
 [tool.cibuildwheel]
 skip = "*i686*"
+before-all = [
+    "curl -L https://micro.mamba.pm/install.sh | bash",
+    "~/.local/bin/micromamba install -y --prefix ~/micromamba cgal-cpp cmake"
+]
+
+[tool.cibuildwheel.environment]
+CMAKE = "$HOME/micromamba/bin/cmake"
 
 [tool.cibuildwheel.linux]
-before-all = [
-    "curl -L https://micro.mamba.pm/install.sh | bash",
-    "~/.local/bin/micromamba install -y --prefix ~/micromamba cgal-cpp cmake"
-]
-# Build wheels for aarch64 under emulation.
+# Build Linux wheels for aarch64 under emulation.
 archs = ["auto", "aarch64"]
-
-[tool.cibuildwheel.linux.environment]
-CMAKE = "$HOME/micromamba/bin/cmake"
-
-[tool.cibuildwheel.macos]
-before-all = [
-    "brew install libomp",
-    "curl -L https://micro.mamba.pm/install.sh | bash",
-    "~/.local/bin/micromamba install -y --prefix ~/micromamba cgal-cpp cmake"
-]
-
-[tool.cibuildwheel.macos.environment]
-CMAKE = "$HOME/micromamba/bin/cmake"
-CC = "$(brew --prefix llvm@15)/bin/clang"
-CXX = "$(brew --prefix llvm@15)/bin/clang++"
-CPPFLAGS = "-I$(brew --prefix libomp)/include"
-LDFLAGS = "-L$(brew --prefix libomp)/lib"


### PR DESCRIPTION
CGAL's 3D natural neighbor coordinates interpolation is not (at least by default) thread safe, and segfaults when we try to evaluate it under OpenMP.
